### PR TITLE
Integration RapidFire-Updates

### DIFF
--- a/FHEM/59_WUup.pm
+++ b/FHEM/59_WUup.pm
@@ -197,10 +197,10 @@ sub WUup_send($) {
     my $version = $hash->{VERSION};
     my $url = "";
     if ($hash->{INTERVAL} < 300) {
-       $url = $hash->{helper}{url};
+       $url = $hash->{helper}{url_rf};
     }
     else {
-       $url = $hash->{helper}{url_rf};
+       $url = $hash->{helper}{url};
     };
     $url .= "?ID=" . $hash->{helper}{stationid};
     $url .= "&PASSWORD=" . $hash->{helper}{password};


### PR DESCRIPTION
Hallo mahowi,

weil meine Wetterstation im 48-Sekunden-Takt Werte sendet, habe mich 'mal daran versucht den RapidFire-Modus (senden von Updates in bis zu 3sec Intervallen: http://wiki.wunderground.com/index.php/PWS_-_Upload_Protocol#RapidFire_Updates) zu ergänzen.
Default Intervall bleibt bei 300 Sekunden kann aber per Attribut auf andere Werte (Minimum 3 sec) gesetzte werden.
Sollte das Intervall auf Werte kleiner 300 gesetzt sein, wird beim Senden dann automatisch die RapiFire-URL verwendet.

Läuft bei mir bisher ohne Probleme.

Bin jetzt nicht so der Modul-Entwickler/Perl-Experte aber vielleicht ist die Integration des RapidFire-Modus auch für andere interessant?

Viele Grüße und danke für das Modul,
Andreas